### PR TITLE
Add the settings object

### DIFF
--- a/index.php
+++ b/index.php
@@ -77,6 +77,11 @@
 //save the sanitized value
 	$_SESSION['app']['edit']['dir'] = $dir;
 
+//ensure we have a settings object for older installs
+if (empty($settings) || !($settings instanceof settings)) {
+	$settings = new settings(['database' => database::new(), 'domain_uuid' => $domain_uuid ?? $_SESSION['domain_uuid'] ?? '', 'user_uuid' => $user_uuid ?? $_SESSION['user_uuid'] ?? '']);
+}
+
 //load editor preferences/defaults
 	$setting_size       = $settings->get('editor', 'font_size', '12px');
 	$setting_theme      = $settings->get('editor', 'theme', 'cobalt');


### PR DESCRIPTION
When edit is run on the current stable or older releases, the error will occur.

Fixes: `Fatal error: Uncaught Error: Call to a member function get() on null in /var/www/fusionpbx/app/edit/index.php:81 Stack trace: #0 {main} thrown in /var/www/fusionpbx/app/edit/index.php on line 81`
